### PR TITLE
modifications to autotools to generate configure w/o errors or warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,3 @@
+Required by Autotools
+
+TO-DO: Add content

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,4 @@
+TO-DO
+
+Insert verbage describing the projects dual-use license.
+

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,3 @@
+Required by Autotools
+
+TO-DO: Add content

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,3 @@
+Required by Autotools
+
+TO-DO: Add content

--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+Required by Autotools
+
+TO-DO: Add content

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+aclocal -I m4
+autoheader
+automake --add-missing
+autoconf
+

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_INIT(zm,2.0.0a,support@zoneminder.com,ZoneMinder,http://www.zoneminder.com/do
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR(src/zm.h)
 AM_CONFIG_HEADER(config.h)
+AC_CONFIG_MACRO_DIR([m4])
 
 PATH_BUILD=`pwd`
 AC_SUBST(PATH_BUILD)

--- a/m4/acdefinedir.m4
+++ b/m4/acdefinedir.m4
@@ -1,0 +1,35 @@
+dnl @synopsis AC_DEFINE_DIR(VARNAME, DIR [, DESCRIPTION])
+dnl
+dnl This macro sets VARNAME to the expansion of the DIR variable,
+dnl taking care of fixing up ${prefix} and such.
+dnl
+dnl VARNAME is then offered as both an output variable and a C
+dnl preprocessor symbol.
+dnl
+dnl Example:
+dnl
+dnl    AC_DEFINE_DIR([DATADIR], [datadir], [Where data are placed to.])
+dnl
+dnl @category Misc
+dnl @author Stepan Kasal <kasal@ucw.cz>
+dnl @author Andreas Schwab <schwab@suse.de>
+dnl @author Guido U. Draheim <guidod@gmx.de>
+dnl @author Alexandre Oliva
+dnl @version 2006-10-13
+dnl @license AllPermissive
+
+AC_DEFUN([AC_DEFINE_DIR], [
+  prefix_NONE=
+  exec_prefix_NONE=
+  test "x$prefix" = xNONE && prefix_NONE=yes && prefix=$ac_default_prefix
+  test "x$exec_prefix" = xNONE && exec_prefix_NONE=yes && exec_prefix=$prefix
+dnl In Autoconf 2.60, ${datadir} refers to ${datarootdir}, which in turn
+dnl refers to ${prefix}.  Thus we have to use `eval' twice.
+  eval ac_define_dir="\"[$]$2\""
+  eval ac_define_dir="\"$ac_define_dir\""
+  AC_SUBST($1, "$ac_define_dir")
+  AC_DEFINE_UNQUOTED($1, "$ac_define_dir", [$3])
+  test "$prefix_NONE" && prefix=NONE
+  test "$exec_prefix_NONE" && exec_prefix=NONE
+])
+


### PR DESCRIPTION
Does the following:
- Adds text files required for Autotools. These files are empty and will need to be populated.
- Add m4 folder and added the required AC_DEFINE_DIR macro file
- Add bootstrap.sh script to generate configure (saves keystrokes)
