### PR TITLE
add cmake build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ Makefile.in
 server/src/zmConfigDefines.h
 docs/server/html/*
 docs/server/doxygen_*
+**/CMakeCache.txt
+**/CMakeFiles
+**/cmake_install.cmake
+


### PR DESCRIPTION
This should match three cmake files/folders mentioned in our slack channel in any folder they appear in.
