### PR TITLE
build static libraries

### DIFF
--- a/server/src/base/CMakeLists.txt
+++ b/server/src/base/CMakeLists.txt
@@ -17,7 +17,7 @@ set(OZ_BASE_HDR_FILES
     "${CMAKE_CURRENT_BINARY_DIR}/ozConfig.h"
    )
 
-add_library(base ${OZ_BASE_SRC_FILES} ${OZ_BASE_HDR_FILES})
+add_library(base STATIC ${OZ_BASE_SRC_FILES} ${OZ_BASE_HDR_FILES})
 
 target_link_libraries(base ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/consumers/CMakeLists.txt
+++ b/server/src/consumers/CMakeLists.txt
@@ -10,7 +10,7 @@ set(OZ_CONSUMER_HDR_FILES
     ozMemoryOutput.h ozMovieFileOutput.h ozMp4FileOutput.h
    )
 
-add_library(consumers ${OZ_CONSUMER_SRC_FILES} ${OZ_CONSUMER_HDR_FILES})
+add_library(consumers STATIC ${OZ_CONSUMER_SRC_FILES} ${OZ_CONSUMER_HDR_FILES})
 
 target_link_libraries(consumers ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/encoders/CMakeLists.txt
+++ b/server/src/encoders/CMakeLists.txt
@@ -8,7 +8,7 @@ set(OZ_ENCODER_HDR_FILES
     ozH264Encoder.h ozH264Relay.h ozMpegEncoder.h ozJpegEncoder.h
    )
 
-add_library(encoders ${OZ_ENCODER_SRC_FILES} ${OZ_ENCODER_HDR_FILES})
+add_library(encoders STATIC ${OZ_ENCODER_SRC_FILES} ${OZ_ENCODER_HDR_FILES})
 
 target_link_libraries(encoders ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/libgen/CMakeLists.txt
+++ b/server/src/libgen/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OZ_LIBGEN_HDR_FILES
     libgenTime.h libgenUtils.h
    )
 
-add_library(gen ${OZ_LIBGEN_SRC_FILES} ${OZ_LIBGEN_HDR_FILES})
+add_library(gen STATIC ${OZ_LIBGEN_SRC_FILES} ${OZ_LIBGEN_HDR_FILES})
 
 target_link_libraries(gen ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/libimg/CMakeLists.txt
+++ b/server/src/libimg/CMakeLists.txt
@@ -9,7 +9,7 @@ set(OZ_LIBIMG_HDR_FILES
     libimgBox.h libimgPoly.h libimgImage.h
    )
 
-add_library(img ${OZ_LIBIMG_SRC_FILES} ${OZ_LIBIMG_HDR_FILES})
+add_library(img STATIC ${OZ_LIBIMG_SRC_FILES} ${OZ_LIBIMG_HDR_FILES})
 
 target_link_libraries(img ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/processors/CMakeLists.txt
+++ b/server/src/processors/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OZ_PROCESSORS_HDR_FILES
     ozVideoFilter.h
    )
 
-add_library(processors ${OZ_PROCESSORS_SRC_FILES} ${OZ_PROCESSORS_HDR_FILES})
+add_library(processors STATIC ${OZ_PROCESSORS_SRC_FILES} ${OZ_PROCESSORS_HDR_FILES})
 
 target_link_libraries(processors ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/protocols/CMakeLists.txt
+++ b/server/src/protocols/CMakeLists.txt
@@ -16,7 +16,7 @@ set(OZ_PROTOCOLS_HDR_FILES
     ozRtspStream.h ozRtpCtrl.h ozRtpData.h ozRtpSession.h
    )
 
-add_library(protocols ${OZ_PROTOCOLS_SRC_FILES} ${OZ_PROTOCOLS_HDR_FILES})
+add_library(protocols STATIC ${OZ_PROTOCOLS_SRC_FILES} ${OZ_PROTOCOLS_HDR_FILES})
 
 target_link_libraries(protocols ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 

--- a/server/src/providers/CMakeLists.txt
+++ b/server/src/providers/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OZ_PROVIDERS_HDR_FILES
     ozRemoteVideoInput.h ozSlaveVideo.h ozVideo4LinuxInput.h
    )
 
-add_library(providers ${OZ_PROVIDERS_SRC_FILES} ${OZ_PROVIDERS_HDR_FILES})
+add_library(providers STATIC ${OZ_PROVIDERS_SRC_FILES} ${OZ_PROVIDERS_HDR_FILES})
 
 target_link_libraries(providers ${OZ_EXTRA_LIBS} ${OZ_BIN_LIBS})
 


### PR DESCRIPTION
Build static libraries to match what autotools did.
See #37 for the question asking why.
