### PR TITLE
allows the prefix for the openh264 project to be configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ ExternalProject_Add(openh264
                     BUILD_COMMAND make
                     INSTALL_COMMAND make install
                                     DESTDIR=${CMAKE_BINARY_DIR}/buildroot
+                                    PREFIX=${CMAKE_INSTALL_PREFIX}
                                     LIBDIR_NAME=${CMAKE_INSTALL_LIBDIR}
                                     SHAREDLIB_DIR=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
                     BUILD_IN_SOURCE 1


### PR DESCRIPTION
This small change allows one to configure the superbuild to "make install" into one's home folder (or any other non-standard location).  This is done by completing the following steps:

``` bash
export DESTDIR=""
cd ~/git/ozonebase
git submodule update --init --recursive
mkdir ~/ozonebase-2.0.0a
cp -r ./* ~/ozonebase-2.0.0a/
cd ~/ozonebase-2.0.0a
cmake -DCMAKE_INSTALL_PREFIX=/ -DOZ_EXAMPLES=ON .
make
export DESTDIR=/home/abauer/install
make install
```

The folder names on your system may vary slightly.

IMPORTANT NOTES to avoid build failures:
- start from a clean, never been built before, project folder
- clear out DESTDIR if it has bee set from previous build attempts
- Perform the commands shown above, in the exact order as shown (setting DESTDIR any sooner will cause the build to fail, for example)
- Do not use sudo or attempt any commands as the root user
