### PR TITLE
cblas is called satlas on some distros

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -467,7 +467,7 @@ else(OZ_SUPERBUILD)
 
     # dlib requires us to link against cblas
     # cblas (using find_library)
-    find_library(CBLAS_LIBRARIES cblas)
+    find_library(CBLAS_LIBRARIES NAMES cblas satlas )
     if(CBLAS_LIBRARIES)
         set(HAVE_LIBCBLAS 1)
         list(APPEND OZ_BIN_LIBS "${CBLAS_LIBRARIES}")


### PR DESCRIPTION
Newer versions of the cblas library have mashed three different libraries, including libcblas.so, into a single library called libsatlas.so
