### PR TITLE
add atlas subfolder to cblas library search path

### DIFF
--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -467,7 +467,7 @@ else(OZ_SUPERBUILD)
 
     # dlib requires us to link against cblas
     # cblas (using find_library)
-    find_library(CBLAS_LIBRARIES NAMES cblas satlas )
+    find_library(CBLAS_LIBRARIES NAMES cblas satlas PATHS /usr/${CMAKE_INSTALL_LIBDIR}/atlas /usr/local/${CMAKE_INSTALL_LIBDIR}/atlas)
     if(CBLAS_LIBRARIES)
         set(HAVE_LIBCBLAS 1)
         list(APPEND OZ_BIN_LIBS "${CBLAS_LIBRARIES}")


### PR DESCRIPTION
When a library is placed under a subfolder of the lib folder, sometimes you have to manually tell cmake where to find the library. This is one of those cases. Required to get cmake to find cblas on CentOS 7, possibly other distros.
