### PR TITLE
add dlib and its dependencies to the superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,6 @@ message(FATAL_ERROR
 endif( NOT EXISTS "${CMAKE_SOURCE_DIR}/externals/ffmpeg/configure" OR
     NOT EXISTS "${CMAKE_SOURCE_DIR}/externals/openh264/Makefile" )
 
-# Delete the buildroot staging folder if it exists from a previous build
-if( EXISTS "${CMAKE_BINARY_DIR}/buildroot" )
-    file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/buildroot")
-endif( EXISTS "${CMAKE_BINARY_DIR}/buildroot" )
-
 # Default build type. To change the build type, 
 # use the CMAKE_BUILD_TYPE configuration option.
 if(NOT CMAKE_BUILD_TYPE)
@@ -27,12 +22,33 @@ if(NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 
 set(OZ_EXAMPLES "OFF" CACHE BOOL "Set to ON to build the oZonebase example binaries. Default: OFF")
+set(OZ_KEEP_BUILDROOT "OFF" CACHE BOOL "Set to ON to prevent oZonebase from deleting the buildroot folder from a previous build attempt. Default: OFF")
 
 # Internal variables. Not to be modified by the end user
 set(OZ_SUPERBUILD "ON" CACHE BOOL INTERNAL)
 set(FFMPEG_PREFIX "${CMAKE_BINARY_DIR}/buildroot${CMAKE_INSTALL_PREFIX}" CACHE PATH INTERNAL)
 set(FFMPEG_LIBDIR "${FFMPEG_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH INTERNAL)
 set(FFMPEG_INCLUDEDIR "${FFMPEG_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH INTERNAL)
+
+# Delete the buildroot staging folder if it exists from a previous build
+if( NOT ${OZ_KEEP_BUILDROOT} AND EXISTS "${CMAKE_BINARY_DIR}/buildroot" )
+    file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/buildroot")
+endif( NOT ${OZ_KEEP_BUILDROOT} AND EXISTS "${CMAKE_BINARY_DIR}/buildroot" )
+
+ExternalProject_Add(dlib
+#                    GIT_REPOSITORY "https://github.com/davisking/dlib"
+#                    GIT_TAG master
+                    DOWNLOAD_COMMAND ""
+                    SOURCE_DIR ${CMAKE_SOURCE_DIR}/externals/dlib
+                    UPDATE_COMMAND ""
+                    CMAKE_ARGS
+                              -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/buildroot${CMAKE_INSTALL_PREFIX}
+                              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                              -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
+                              -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                              -DLIB_INSTALL_DIR=${CMAKE_INSTALL_LIBDIR}
+                   )
+
 
 ExternalProject_Add(openh264
 #                    GIT_REPOSITORY "https://github.com/cisco/openh264"

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -292,7 +292,6 @@ if(OZ_SUPERBUILD)
         message(FATAL_ERROR 
                 "oZone requires swscale but it was not found on your system")
     endif(SWSCALE_LIBRARIES)
-
     # avfilter (built as external project, using find_library and find_path)
     find_library(AVFILTER_LIBRARIES avfilter PATHS "${FFMPEG_LIBDIR}" NO_DEFAULT_PATH)
     if(AVFILTER_LIBRARIES)
@@ -327,6 +326,52 @@ if(OZ_SUPERBUILD)
                 "oZone requires swresample but it was not found on your system")
     endif(SWRESAMPLE_LIBRARIES)
 
+    # dlib (using find_library and find_path)
+    find_library(DLIB_LIBRARIES dlib PATHS "${FFMPEG_LIBDIR}" NO_DEFAULT_PATH)
+    if(DLIB_LIBRARIES)
+        set(HAVE_LIBDLIB 1)
+        list(APPEND OZ_BIN_LIBS "${DLIB_LIBRARIES}")
+        find_path(IMG_PROCESSING_INCLUDE_DIR "dlib/image_processing/frontal_face_detector.h" PATHS "${FFMPEG_INCLUDEDIR}" NO_DEFAULT_PATH)
+message(STATUS "Value of IMG_PROCESSING_INCLUDE_DIR: ${IMG_PROCESSING_INCLUDE_DIR}")
+        if(IMG_PROCESSING_INCLUDE_DIR)
+            include_directories("${IMG_PROCESSING_INCLUDE_DIR}")
+            set(CMAKE_REQUIRED_INCLUDES "${IMG_PROCESSING_INCLUDE_DIR}")
+        endif(IMG_PROCESSING_INCLUDE_DIR)
+        mark_as_advanced(FORCE DLIB_LIBRARIES)
+    else(DLIB_LIBRARIES)
+        message(FATAL_ERROR
+                "oZone requires dlib but it was not found on your system")
+    endif(DLIB_LIBRARIES)
+
+    # dlib requires us to link against cblas
+    # cblas (using find_library)
+    # This check is a little different than the others
+    # It will look for libcblas in the standard locations, in addition to the buildroot include folder
+    # rather than only in the buildroot include folder
+    find_library(CBLAS_LIBRARIES NAMES cblas satlas PATHS "/usr/${CMAKE_INSTALL_LIBDIR}/atlas" "/usr/local/${CMAKE_INSTALL_LIBDIR}/atlas" "${FFMPEG_LIBDIR}")
+    if(CBLAS_LIBRARIES)
+        set(HAVE_LIBCBLAS 1)
+        list(APPEND OZ_BIN_LIBS "${CBLAS_LIBRARIES}")
+        mark_as_advanced(FORCE CBLAS_LIBRARIES)
+    else(CBLAS_LIBRARIES)
+        message(FATAL_ERROR
+                "oZone requires cblas but it was not found on your system")
+    endif(CBLAS_LIBRARIES)
+
+    # dlib requires us to link against lapack
+    # lapack (using find_library)
+    # This check is a little different than the others
+    # It will look for liblapack in the standard locations, in addition to the buildroot include folder
+    # rather than only in the buildroot include folder
+    find_library(LAPACK_LIBRARIES lapack PATHS "${FFMPEG_LIBDIR}")
+    if(LAPACK_LIBRARIES)
+        set(HAVE_LIBCLAPACK 1)
+        list(APPEND OZ_BIN_LIBS "${LAPACK_LIBRARIES}")
+        mark_as_advanced(FORCE LAPACK_LIBRARIES)
+    else(LAPACK_LIBRARIES)
+        message(FATAL_ERROR
+                "oZone requires lapack but it was not found on your system")
+    endif(LAPACK_LIBRARIES)
 else(OZ_SUPERBUILD)
 
     # avformat (using find_library and find_path)
@@ -586,5 +631,4 @@ message(STATUS "Optional libraries found:${optlibsfound}")
 message(STATUS "Optional libraries not found:${optlibsnotfound}")
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/config.h" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/ozonebase")
-
 


### PR DESCRIPTION
Note that cmake only checks for the dlib dependencies liblapack and libcblas. You will need to install them onto your filesystem prior to running the superbuild. Note that we can change this behaviour to something else if we need to.
