### PR TITLE
demoted several info logs to Debug 1 or 2

### DIFF
--- a/server/src/base/ozController.cpp
+++ b/server/src/base/ozController.cpp
@@ -11,7 +11,7 @@
 */
 void Controller::addStream( const std::string &streamName, const std::string &streamClass )
 {
-    Info( "Adding stream %s with class %s", streamName.c_str(), streamClass.c_str() );
+    Debug(1, "Adding stream %s with class %s", streamName.c_str(), streamClass.c_str() );
     std::pair<ApplicationClassMap::iterator,bool> result = mApplicationClasses.insert( ApplicationClassMap::value_type( streamName, streamClass ) );
     if ( !result.second )
         Fatal( "Unable to add stream %s with class %s", streamName.c_str(), streamClass.c_str() );
@@ -84,7 +84,7 @@ FeedProvider *Controller::findStream( const std::string &streamName, const std::
     if ( instanceIter != mApplicationClasses.end() )
     {
         std::string feedId = FeedProvider::makeIdentity( instanceIter->second, streamSource );
-        Info( "Looking for feed %s", feedId.c_str() );
+        Debug( 1,"Looking for feed %s", feedId.c_str() );
         return( FeedProvider::find( feedId ) );
     }
     Info( "Failed" );

--- a/server/src/base/ozFeedConsumer.cpp
+++ b/server/src/base/ozFeedConsumer.cpp
@@ -130,7 +130,7 @@ bool FeedConsumer::waitForProviders()
             {
                 if ( iter->first->wait() )
                 {
-                    Info( "%s: Provider %s not ready", cidentity(), iter->first->cidentity() );
+                    Debug(1, "%s: Provider %s not ready", cidentity(), iter->first->cidentity() );
                     waitCount++;
                 }
                 else

--- a/server/src/base/ozFfmpeg.cpp
+++ b/server/src/base/ozFfmpeg.cpp
@@ -226,11 +226,11 @@ const char *avStrError( int error )
 */
 void avDumpDict( AVDictionary *dict )
 {
-    Info( "Dictionary" );
+    Debug( 2,"Dictionary" );
     const AVDictionaryEntry *entry = NULL;
     while( (entry = av_dict_get( dict, "", entry, AV_DICT_IGNORE_SUFFIX )) )
     {
-        Info( "Dict: %s = %s", entry->key, entry->value );
+        Debug( 1,"Dict: %s = %s", entry->key, entry->value );
     }
 }
 

--- a/server/src/base/ozMemoryIO.cpp
+++ b/server/src/base/ozMemoryIO.cpp
@@ -139,7 +139,7 @@ bool MemoryIO::queryMemory( SharedData *sharedData )
 void MemoryIO::attachMemory( int imageCount, AVPixelFormat imageFormat, uint16_t imageWidth, uint16_t imageHeight )
 {
     Image tempImage( imageFormat, imageWidth, imageHeight, 0 );
-    Info( "Pixelformat converted from %d to %d", imageFormat, tempImage.pixelFormat() );
+    Debug( 1,"Pixelformat converted from %d to %d", imageFormat, tempImage.pixelFormat() );
     size_t imageSize = tempImage.size();
 
     mMemSize = sizeof(SharedData)

--- a/server/src/base/ozMemoryIOV1.cpp
+++ b/server/src/base/ozMemoryIOV1.cpp
@@ -143,7 +143,7 @@ void MemoryIOV1::attachMemory( int imageCount, AVPixelFormat imageFormat, uint16
         Fatal( "Unable to attach to shared memory, already attached" );
     mImageCount = imageCount;
     Image tempImage( imageFormat, imageWidth, imageHeight, 0 );
-    Info( "AVPixelformat converted from %d to %d", imageFormat, tempImage.pixelFormat() );
+    Debug( 1,"AVPixelformat converted from %d to %d", imageFormat, tempImage.pixelFormat() );
     size_t imageSize = tempImage.size();
 
     mMemSize = sizeof(SharedData)

--- a/server/src/consumers/ozLocalFileDump.cpp
+++ b/server/src/consumers/ozLocalFileDump.cpp
@@ -38,7 +38,7 @@ int LocalFileDump::run()
                 for ( FrameQueue::iterator iter = mFrameQueue.begin(); iter != mFrameQueue.end(); iter++ )
                 {
                     const FeedFrame *frame = iter->get();
-                    Info( "F:%ld", frame->buffer().size() );
+                    Debug(1, "F:%ld", frame->buffer().size() );
                     if ( filePath.empty() )
                     {
                         filePath = stringtf( "%s/%s-%s", mLocation.c_str(), mName.c_str(), frame->provider()->cidentity() );

--- a/server/src/consumers/ozLocalFileOutput.cpp
+++ b/server/src/consumers/ozLocalFileOutput.cpp
@@ -44,7 +44,7 @@ int LocalFileOutput::run()
 bool LocalFileOutput::writeFrame( const FeedFrame *frame )
 {
     std::string path = stringtf( "%s/img-%s-%ju.jpg", mLocation.c_str(), mName.c_str(), frame->id() );
-    Info( "Path: %s", path.c_str() );
+    Debug( 1,"Path: %s", path.c_str() );
     const VideoFrame *videoFrame = dynamic_cast<const VideoFrame *>(frame);
     //const VideoProvider *provider = dynamic_cast<const VideoProvider *>(frame->provider());
     //Info( "PF:%d @ %dx%d", videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height() );

--- a/server/src/consumers/ozMemoryOutput.cpp
+++ b/server/src/consumers/ozMemoryOutput.cpp
@@ -85,7 +85,7 @@ int MemoryOutput::run()
 bool MemoryOutput::storeFrame( FramePtr frame )
 {
     const VideoFrame *videoFrame = dynamic_cast<const VideoFrame *>(frame.get());
-    Info( "PF:%d @ %dx%d", videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height() );
+    Debug(1, "PF:%d @ %dx%d", videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height() );
 
     Image image( videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height(), frame->buffer().data() );
 

--- a/server/src/consumers/ozMovieFileOutput.cpp
+++ b/server/src/consumers/ozMovieFileOutput.cpp
@@ -30,7 +30,7 @@ int MovieFileOutput::run()
         PixelFormat inputPixelFormat = videoProvider()->pixelFormat();
         FrameRate inputFrameRate = videoProvider()->frameRate();
 
-        Info( "Provider framerate = %d/%d", inputFrameRate.num, inputFrameRate.den );
+        Debug(1, "Provider framerate = %d/%d", inputFrameRate.num, inputFrameRate.den );
 
         /* auto detect the output format from the name. default is mpeg. */
         AVOutputFormat *outputFormat = av_guess_format( mFormat.c_str(), NULL, NULL );
@@ -231,7 +231,7 @@ int MovieFileOutput::run()
 
                         if ( ( !audioStream || (audioTimeOffset >= mMaxLength) ) && ( !videoStream || (videoTimeOffset >= mMaxLength) ) )
                             fileComplete = true;
-                        Info( "PTS: %lf, %jd, %jd", videoTimeOffset, videoCodecContext->coded_frame->pts, videoStream->pts.val );
+                        Debug(1, "PTS: %lf, %jd, %jd", videoTimeOffset, videoCodecContext->coded_frame->pts, videoStream->pts.val );
 
                         const FeedFrame *frame = iter->get();
                         /* write interleaved audio and video frames */
@@ -259,7 +259,7 @@ int MovieFileOutput::run()
                         else
                         {
                             const VideoFrame *videoFrame = dynamic_cast<const VideoFrame *>(frame);
-                            Info( "PF:%d @ %dx%d", videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height() );
+                            Debug(1, "PF:%d @ %dx%d", videoFrame->pixelFormat(), videoFrame->width(), videoFrame->height() );
 
                             avpicture_fill( (AVPicture *)avInputFrame, videoFrame->buffer().data(), inputPixelFormat, inputWidth, inputHeight );
                             // XXX - Hack???
@@ -287,7 +287,7 @@ int MovieFileOutput::run()
                             int result = 0;
                             if ( outputContext->oformat->flags & AVFMT_RAWPICTURE )
                             {
-                                Info( "Raw frame" );
+                                Debug(1, "Raw frame" );
                                 /* raw video case. The API will change slightly in the near futur for that */
                                 AVPacket pkt;
                                 av_init_packet(&pkt);
@@ -301,14 +301,14 @@ int MovieFileOutput::run()
                             }
                             else
                             {
-                                Info( "Encoded frame" );
+                                Debug( 1,"Encoded frame" );
                                 int outSize = 0;
                                 do
                                 {
                                     /* encode the image */
                                     outSize = avcodec_encode_video( videoCodecContext, videoBuffer.data(), videoBuffer.capacity(), avOutputFrame );
                                     /* if zero size, it means the image was buffered */
-                                    Info( "Outsize: %d", outSize );
+                                    Debug(1, "Outsize: %d", outSize );
                                     if ( outSize > 0 )
                                     {
                                         AVPacket pkt;

--- a/server/src/consumers/ozMp4FileOutput.cpp
+++ b/server/src/consumers/ozMp4FileOutput.cpp
@@ -245,7 +245,7 @@ int Mp4FileOutput::run()
 								packet.size = frame->buffer().size();
 								//packet.pts = packet.dts = AV_NOPTS_VALUE;
 								packet.pts = packet.dts = (videoFrameCount * mVideoParms.frameRate().num * videoCodecContext->time_base.den) / (mVideoParms.frameRate().den * videoCodecContext->time_base.num);
-								Info( "vfc: %ju, vto: %.2lf, kf: %d, pts: %jd", videoFrameCount, videoTimeOffset, keyFrame, packet.pts );
+								Debug(1, "vfc: %ju, vto: %.2lf, kf: %d, pts: %jd", videoFrameCount, videoTimeOffset, keyFrame, packet.pts );
 
 								int result = av_interleaved_write_frame(outputContext, &packet);
 								if ( result != 0 )

--- a/server/src/consumers/ozVideoRecorder.cpp
+++ b/server/src/consumers/ozVideoRecorder.cpp
@@ -18,7 +18,7 @@ int VideoRecorder::run()
         setReady();
 
         FrameRate inputFrameRate = videoProvider()->frameRate();
-        Info( "Provider framerate = %d/%d", inputFrameRate.num, inputFrameRate.den );
+        Debug(1, "Provider framerate = %d/%d", inputFrameRate.num, inputFrameRate.den );
 
         //initEncoder();
         while( !mStop )

--- a/server/src/encoders/ozH264Encoder.cpp
+++ b/server/src/encoders/ozH264Encoder.cpp
@@ -180,10 +180,10 @@ int H264Encoder::run()
     avDumpDict( opts );
     AVFrame *inputFrame = avcodec_alloc_frame();
 
-    Info( "%s:Waiting", cidentity() );
+    Debug(1, "%s:Waiting", cidentity() );
     if ( waitForProviders() )
     {
-        Info( "%s:Waited", cidentity() );
+        Debug(1, "%s:Waited", cidentity() );
 
         // Find the source codec context
         uint16_t inputWidth = videoProvider()->width();

--- a/server/src/encoders/ozH264Relay.cpp
+++ b/server/src/encoders/ozH264Relay.cpp
@@ -156,10 +156,10 @@ int H264Relay::run()
 
     //const unsigned char startCode[] = { 0x00, 0x00, 0x00, 0x01 };
 
-    Info( "%s:Waiting", cidentity() );
+    Debug( 1,"%s:Waiting", cidentity() );
     if ( waitForProviders() )
     {
-        Info( "%s:Waited", cidentity() );
+        Debug( 1,"%s:Waited", cidentity() );
 
         //uint16_t inputWidth = videoProvider()->width();
         //uint16_t inputHeight = videoProvider()->height();

--- a/server/src/encoders/ozJpegEncoder.cpp
+++ b/server/src/encoders/ozJpegEncoder.cpp
@@ -96,8 +96,8 @@ int JpegEncoder::run()
         struct SwsContext *convertContext = sws_getContext( inputWidth, inputHeight, inputPixelFormat, mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt, SWS_BICUBIC, NULL, NULL, NULL );
         if ( !convertContext )
             Fatal( "Unable to create conversion context for encoder" );
-        Info( "Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt );
-        Info( "%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mCodecContext->pix_fmt, mCodecContext->width, mCodecContext->height ) );
+        Debug(1, "Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, mCodecContext->width, mCodecContext->height, mCodecContext->pix_fmt );
+        Debug( 1,"%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mCodecContext->pix_fmt, mCodecContext->width, mCodecContext->height ) );
 
         int outSize = 0;
         double timeInterval = (double)mCodecContext->time_base.num/mCodecContext->time_base.den;
@@ -139,7 +139,7 @@ int JpegEncoder::run()
 
                     if ( inputVideoFrame )
                     {
-                        Info( "PF:%d @ %dx%d", inputVideoFrame->pixelFormat(), inputVideoFrame->width(), inputVideoFrame->height() );
+                        Debug( 1,"PF:%d @ %dx%d", inputVideoFrame->pixelFormat(), inputVideoFrame->width(), inputVideoFrame->height() );
 
                         //encodeFrame( frame );
                         avpicture_fill( (AVPicture *)inputFrame, inputVideoFrame->buffer().data(), inputPixelFormat, inputWidth, inputHeight );
@@ -149,7 +149,7 @@ int JpegEncoder::run()
                         //outputFrame->pts = av_rescale_q( inputVideo.timestamp, mCodecContext->time_base, sourceCodecContext->time_base );
 
                         // Reformat the input frame to fit the desired output format
-                        Info( "oFd:%p, oFls:%d", outputFrame->data, *(outputFrame->linesize) );
+                        Debug(1, "oFd:%p, oFls:%d", outputFrame->data, *(outputFrame->linesize) );
                         if ( sws_scale( convertContext, inputFrame->data, inputFrame->linesize, 0, inputHeight, outputFrame->data, outputFrame->linesize ) < 0 )
                             Fatal( "Unable to convert input frame (%d@%dx%d) to output frame (%d@%dx%d) at frame %ju", inputPixelFormat, inputWidth, inputHeight, mCodecContext->pix_fmt, mCodecContext->width, mCodecContext->height, mFrameCount );
 

--- a/server/src/encoders/ozMpegEncoder.cpp
+++ b/server/src/encoders/ozMpegEncoder.cpp
@@ -151,10 +151,10 @@ int MpegEncoder::run()
     avDumpDict( opts );
     AVFrame *inputFrame = avcodec_alloc_frame();
 
-    Info( "%s:Waiting", cidentity() );
+    Debug(1, "%s:Waiting", cidentity() );
     if ( waitForProviders() )
     {
-        Info( "%s:Waited", cidentity() );
+        Debug( 1,"%s:Waited", cidentity() );
 
         // Find the source codec context
         uint16_t inputWidth = videoProvider()->width();
@@ -231,7 +231,7 @@ int MpegEncoder::run()
                 Debug( 5, "Encoding reports %d bytes", outSize );
                 if ( outSize > 0 )
                 {
-                    Info( "CPTS: %jd", mCodecContext->coded_frame->pts );
+                    Debug( 2,"CPTS: %jd", mCodecContext->coded_frame->pts );
                     outputBuffer.size( outSize );
                     //Debug( 5, "PTS2 %lld", mCodecContext->coded_frame->pts );
                     //av_rescale_q(cocontext->coded_frame->pts, cocontext->time_base, videostm->time_base); 

--- a/server/src/examples/nvrcli/nvrcli.cpp
+++ b/server/src/examples/nvrcli/nvrcli.cpp
@@ -449,7 +449,7 @@ void cli(Application app)
 
 int main( int argc, const char *argv[] )
 {
-    dbgInit( "nvrcli", "", 5 );
+    dbgInit( "nvrcli", "", 0 );
     cout << " \n---------------------- NVRCLI ------------------\n"
              " Type help to get started\n"
              " ------------------------------------------------\n\n";

--- a/server/src/libimg/libimgImage.cpp
+++ b/server/src/libimg/libimgImage.cpp
@@ -1337,7 +1337,7 @@ unsigned char Image::v( int x, int y ) const
 */
 void Image::dump( int lines, int cols ) const
 {
-    Info( "DUMP-F%d, %dx%d", mFormat, mWidth, mHeight );
+    Debug( 1,"DUMP-F%d, %dx%d", mFormat, mWidth, mHeight );
     if ( lines > 0 )
     {
         if ( lines > mHeight )
@@ -1346,7 +1346,7 @@ void Image::dump( int lines, int cols ) const
             cols = mWidth;
         if ( mPlanes == 1 )
         {
-            Info( "DUMP-%d channels", mChannels );
+            Debug( 1,"DUMP-%d channels", mChannels );
             for ( int y = 0; y < lines; y++ )
             {
                 Hexdump( 0, mBuffer.data()+(mStride*y), cols*mChannels*mPixelWidth );
@@ -1355,7 +1355,7 @@ void Image::dump( int lines, int cols ) const
         else
         {
             unsigned char *yPtr = mBuffer.data();
-            Info( "DUMP-Y-Channel" );
+            Debug( 1,"DUMP-Y-Channel" );
             for ( int y = 0; y < lines; y++ )
             {
                 Hexdump( 0, yPtr+(mStride*y), cols*mPixelWidth );
@@ -1363,7 +1363,7 @@ void Image::dump( int lines, int cols ) const
             if ( mChannels > 1 )
             {
                 unsigned char *uPtr = yPtr+mPlaneSize;
-                Info( "DUMP-U-Channel" );
+                Debug( 1,"DUMP-U-Channel" );
                 for ( int y = 0; y < lines; y++ )
                 {
                     Hexdump( 0, uPtr+(mStride*y), cols*mPixelWidth );

--- a/server/src/processors/ozAVFilter.cpp
+++ b/server/src/processors/ozAVFilter.cpp
@@ -168,14 +168,14 @@ int VideoFilter::run()
         avfilter_inout_free( &inputs );
         avfilter_inout_free( &outputs );
 
-        Info( "Applying filter '%s'", mFilter.c_str() );
+        Debug( 1,"Applying filter '%s'", mFilter.c_str() );
 
         int outputWidth = width();
         int outputHeight = height();
         PixelFormat outputPixelFormat = pixelFormat();
         ByteBuffer outputBuffer;
 
-        Info( "Filtering from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, outputWidth, outputHeight, outputPixelFormat );
+        Debug(1, "Filtering from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, outputWidth, outputHeight, outputPixelFormat );
 
         // Make space for anything that is going to be output
         outputBuffer.size( avpicture_get_size( outputPixelFormat, outputWidth, outputHeight ) );

--- a/server/src/processors/ozFaceDetector.cpp
+++ b/server/src/processors/ozFaceDetector.cpp
@@ -61,7 +61,7 @@ int FaceDetector::run()
         AVPixelFormat pixelFormat = videoProvider()->pixelFormat();
         int16_t width = videoProvider()->width();
         int16_t height = videoProvider()->height();
-        Info( "pf:%d, %dx%d", pixelFormat, width, height );
+        Debug( 2, "pf:%d, %dx%d", pixelFormat, width, height );
 
         // We need a face detector.  We will use this to get bounding boxes for
         // each face in an image.
@@ -98,7 +98,7 @@ int FaceDetector::run()
                         //dlib::pyramid_up(img);
                         //Info( "AFT: %d x %d", num_rows(img), num_columns(img) );
                         std::vector<dlib::rectangle> dets = detector(img);
-                        Info( "%jd @ %ju: Got %jd faces", frame->id(), frame->timestamp(), dets.size() );
+                        Debug( 1, "%jd @ %ju: Got %jd faces", frame->id(), frame->timestamp(), dets.size() );
 
                         if ( dets.size() > 0 && mFaceMarkup != OZ_FACE_MARKUP_NONE )
                         {
@@ -116,7 +116,7 @@ int FaceDetector::run()
                                 if ( mFaceMarkup & OZ_FACE_MARKUP_DETAIL )
                                 {
                                     dlib::full_object_detection shape = sp(img, dets[i]);
-                                    Info( "Face %u - %ju parts", i, shape.num_parts() );
+                                    Debug( 2, "Face %u - %ju parts", i, shape.num_parts() );
 
                                     // Around Chin. Ear to Ear
                                     for (unsigned long p = 1; p <= 16; ++p)

--- a/server/src/processors/ozFilterSwapUV.cpp
+++ b/server/src/processors/ozFilterSwapUV.cpp
@@ -66,7 +66,7 @@ int FilterSwapUV::run()
                     //FramePtr framePtr( *iter );
                     const FeedFrame *frame = (*iter).get();
 
-                    Info( "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
+                    Debug(1, "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
 
                     //Image image( inputPixelFormat, inputWidth, inputHeight, frame->buffer().data() );
 

--- a/server/src/processors/ozImageConvert.cpp
+++ b/server/src/processors/ozImageConvert.cpp
@@ -69,8 +69,8 @@ int ImageConvert::run()
         if ( !mConvertContext )
             Fatal( "Unable to create conversion context" );
 
-        Info( "Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, mWidth, mHeight, mPixelFormat );
-        Info( "%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mPixelFormat, mWidth, mHeight ) );
+        Debug( 1, "Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, mWidth, mHeight, mPixelFormat );
+        Debug( 1,"%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mPixelFormat, mWidth, mHeight ) );
 
         // Make space for anything that is going to be output
         ByteBuffer outputBuffer;
@@ -94,7 +94,7 @@ int ImageConvert::run()
                     if ( mWidth != inputWidth || mHeight != inputHeight || mPixelFormat != inputPixelFormat )
                     {
                         // Requires conversion
-                        Info( "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
+                        Debug( 1, "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
 
                         avpicture_fill( (AVPicture *)inputFrame, frame->buffer().data(), inputPixelFormat, inputWidth, inputHeight );
 

--- a/server/src/processors/ozImageScale.cpp
+++ b/server/src/processors/ozImageScale.cpp
@@ -76,8 +76,8 @@ int ImageScale::run()
         if ( !mScaleContext )
             Fatal( "Unable to create scale context" );
 
-        Info( "Scaling from %d x %d -> %d x %d", inputWidth, inputHeight, mWidth, mHeight );
-        Info( "%d bytes -> %d bytes",  avpicture_get_size( pixelFormat, inputWidth, inputHeight ), avpicture_get_size( pixelFormat, mWidth, mHeight ) );
+        Debug( 1,"Scaling from %d x %d -> %d x %d", inputWidth, inputHeight, mWidth, mHeight );
+        Debug( 1,"%d bytes -> %d bytes",  avpicture_get_size( pixelFormat, inputWidth, inputHeight ), avpicture_get_size( pixelFormat, mWidth, mHeight ) );
 
         // Make space for anything that is going to be output
         ByteBuffer outputBuffer;
@@ -101,7 +101,7 @@ int ImageScale::run()
                     if ( mWidth != inputWidth || mHeight != inputHeight )
                     {
                         // Requires conversion
-                        Info( "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
+                        Debug( 1,"%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
 
                         avpicture_fill( (AVPicture *)inputFrame, frame->buffer().data(), pixelFormat, inputWidth, inputHeight );
 

--- a/server/src/processors/ozImageTimestamper.cpp
+++ b/server/src/processors/ozImageTimestamper.cpp
@@ -64,7 +64,7 @@ int ImageTimestamper::run()
                     //FramePtr framePtr( *iter );
                     const FeedFrame *frame = (*iter).get();
 
-                    Info( "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
+                    Debug(1, "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %lu", cname(), frame->provider()->cidentity(), frame->originator()->cidentity(), frame, frame->id(), frame->age(), frame->buffer().size() );
 
                     Image image( inputPixelFormat, inputWidth, inputHeight, frame->buffer().data() );
 

--- a/server/src/processors/ozMatrixVideo.cpp
+++ b/server/src/processors/ozMatrixVideo.cpp
@@ -158,7 +158,7 @@ int MatrixVideo::run()
                         if ( frame )
                         {
                             const VideoFrame *inputVideoFrame = dynamic_cast<const VideoFrame *>(frame);
-                            Info( "PF:%d @ %dx%d", inputVideoFrame->pixelFormat(), inputVideoFrame->width(), inputVideoFrame->height() );
+                            Debug( 2,"PF:%d @ %dx%d", inputVideoFrame->pixelFormat(), inputVideoFrame->width(), inputVideoFrame->height() );
                             const VideoProvider *videoProvider = inputVideoFrame->videoProvider();
 
                             if ( !mInterFrames[i] )
@@ -211,8 +211,8 @@ int MatrixVideo::run()
                                 if ( !convertContext )
                                     Fatal( "Unable to create conversion context for provider %s", videoProvider->cidentity() );
             
-                                Info( "Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, interWidth, interHeight, mPixelFormat );
-                                Info( "%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mPixelFormat, interWidth, interHeight ) );
+                                Debug( 1,"Converting from %d x %d @ %d -> %d x %d @ %d", inputWidth, inputHeight, inputPixelFormat, interWidth, interHeight, mPixelFormat );
+                                Debug( 2, "%d bytes -> %d bytes",  avpicture_get_size( inputPixelFormat, inputWidth, inputHeight ), avpicture_get_size( mPixelFormat, interWidth, interHeight ) );
                             }
                             avpicture_fill( (AVPicture *)inputFrame, inputVideoFrame->buffer().data(), inputPixelFormat, inputWidth, inputHeight );
 
@@ -324,7 +324,7 @@ int MatrixVideo::run()
             {
                 const VideoFrame *inputFrame = dynamic_cast<const VideoFrame *>(iter->get());
 
-                Info( "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %d", cid(), inputFrame->provider()->cidentity(), inputFrame->originator()->cidentity(), inputFrame, inputFrame->id(), inputFrame->age(), inputFrame->buffer().size() );
+                Debug(1, "%s / Provider: %s, Source: %s, Frame: %p (%ju / %.3f) - %d", cid(), inputFrame->provider()->cidentity(), inputFrame->originator()->cidentity(), inputFrame, inputFrame->id(), inputFrame->age(), inputFrame->buffer().size() );
 
                 avInputFrameSize = avpicture_get_size( inputFrame->pixelFormat(), inputFrame->width(), inputFrame->height() );
                 avcodec_get_frame_defaults( &avInputFrame );

--- a/server/src/processors/ozMotionDetector.cpp
+++ b/server/src/processors/ozMotionDetector.cpp
@@ -117,7 +117,7 @@ int MotionDetector::run()
         AVPixelFormat pixelFormat = videoProvider()->pixelFormat();
         int16_t width = videoProvider()->width();
         int16_t height = videoProvider()->height();
-        Info( "pf:%d, %dx%d", pixelFormat, width, height );
+        Debug( 2,"pf:%d, %dx%d", pixelFormat, width, height );
 
         if ( !mZones.size() )
         {
@@ -166,10 +166,11 @@ int MotionDetector::run()
                         //motionData.reset();
 
                         analyse( &image, motionData, &motionImage );
-                        if ( mAlarmed )
+                        /*if ( mAlarmed )
                         {
-                            Info( "ALARM" );
-                        }
+
+                           Info( "ALARM" );
+                        }*/
                         // XXX - Generate a new timestamp as using the original frame may be subject to process/decoding delays
                         // Need to check if there is a better way to handle this generally
                         MotionFrame *motionFrame = new MotionFrame( this, *iter, mFrameCount, time64(), motionImage.buffer(), mAlarmed, motionData );
@@ -229,7 +230,7 @@ bool MotionDetector::analyse( const Image *compImage, MotionData *motionData, Im
         uint64_t motionScore = detectMotion( *compImage, detectedZones );
         if ( motionScore )
         {
-            Info( "Score: %ld", motionScore );
+            Debug(1, "Score: %ld", motionScore );
             if ( !mAlarmed )
             {
                 score += motionScore;

--- a/server/src/processors/ozShapeDetector.cpp
+++ b/server/src/processors/ozShapeDetector.cpp
@@ -60,7 +60,7 @@ int ShapeDetector::run()
         AVPixelFormat pixelFormat = videoProvider()->pixelFormat();
         int16_t width = videoProvider()->width();
         int16_t height = videoProvider()->height();
-        Info( "pf:%d, %dx%d", pixelFormat, width, height );
+        Debug( 1,"pf:%d, %dx%d", pixelFormat, width, height );
 
         typedef dlib::scan_fhog_pyramid<dlib::pyramid_down<6> > image_scanner_type;
 
@@ -92,7 +92,7 @@ int ShapeDetector::run()
                         //dlib::pyramid_up(img);
                         //Info( "AFT: %d x %d", num_rows(img), num_columns(img) );
                         std::vector<dlib::rectangle> dets = detector(img);
-                        Info( "%jd @ %ju: Got %jd shapes", frame->id(), frame->timestamp(), dets.size() );
+                        Debug( 1,"%jd @ %ju: Got %jd shapes", frame->id(), frame->timestamp(), dets.size() );
 
                         if ( dets.size() > 0 && mShapeMarkup != OZ_SHAPE_MARKUP_NONE )
                         {

--- a/server/src/processors/ozSignalChecker.cpp
+++ b/server/src/processors/ozSignalChecker.cpp
@@ -153,7 +153,7 @@ bool SignalChecker::signalValid( FramePtr frame, const FeedConsumer * )
     const SignalChecker *signalChecker = dynamic_cast<const SignalChecker *>( videoFrame->provider() );
     if ( !signalChecker )
         Panic( "Can't check signal valid, frame source not signal checker" );
-    Info( "Checking valid - %d", signalChecker->hasSignal() );
+    Debug( 2,"Checking valid - %d", signalChecker->hasSignal() );
     return( signalChecker->hasSignal() );
 }
 

--- a/server/src/providers/ozAVInput.cpp
+++ b/server/src/providers/ozAVInput.cpp
@@ -58,7 +58,7 @@ int AVInput::decodePacket( AVPacket &packet, int &frameComplete )
                 avpicture_layout( (AVPicture *)mVideoFrame, mVideoCodecContext->pix_fmt, mVideoCodecContext->width, mVideoCodecContext->height, mVideoFrameBuffer.data(), mVideoFrameBuffer.capacity() );
 
                 mLastTimestamp = mBaseTimestamp + (1000000.0L*timeOffset);
-                Info( "%ld: TS: %jd, TS1: %jd, TS2: %jd, TS3: %.3f", time( 0 ), mLastTimestamp, packet.pts, (uint64_t)(1000000.0L*timeOffset), timeOffset );
+                Debug( 1,"%ld: TS: %jd, TS1: %jd, TS2: %jd, TS3: %.3f", time( 0 ), mLastTimestamp, packet.pts, (uint64_t)(1000000.0L*timeOffset), timeOffset );
 
                 if ( mRealtime )
                 {
@@ -144,7 +144,7 @@ int AVInput::run()
 
         while ( !mStop )
         {
-            Info ("AVInput mStop is:%d",mStop);
+            //Info ("AVInput mStop is:%d",mStop);
             AVFormatContext *formatContext = NULL;
             if ( avformat_open_input( &formatContext, mSource.c_str(), inputFormat, /*&dict*/NULL ) !=0 )
                 Fatal( "Unable to open input %s due to: %s", mSource.c_str(), strerror(errno) );

--- a/server/src/providers/ozMemoryInput.cpp
+++ b/server/src/providers/ozMemoryInput.cpp
@@ -36,13 +36,13 @@ int MemoryInput::run()
 
     while( !mStop )
     {
-        Info( "Querying memory" );
+        Debug( 2,"Querying memory" );
         if ( queryMemory( &sharedData ) && sharedData.valid )
             break;
         Info( "Can't query shared memory" );
         usleep( 500000 );
     }
-    Info( "SHV: %d", sharedData.valid );
+    Debug( 2,"SHV: %d", sharedData.valid );
     mImageFormat = sharedData.imageFormat;
     mImageWidth = sharedData.imageWidth;
     mImageHeight = sharedData.imageHeight;

--- a/server/src/providers/ozMemoryInputV1.cpp
+++ b/server/src/providers/ozMemoryInputV1.cpp
@@ -51,7 +51,7 @@ int MemoryInputV1::run()
 
     while( !mStop )
     {
-        Info( "Querying memory" );
+        Debug( 2,"Querying memory" );
         if ( queryMemory( &sharedData ) && sharedData.valid )
             break;
         Info( "Can't query shared memory" );

--- a/server/src/providers/ozRawH264Input.cpp
+++ b/server/src/providers/ozRawH264Input.cpp
@@ -198,7 +198,7 @@ int RawH264Input::run()
 
                     //DataFrame *dataFrame = new DataFrame( this, videoFrameCount, packet.pts, packet.data, packet.size );
                     //distributeFrame( FramePtr( dataFrame ) );
-                    Info( "In packet %d(%x)", packet.size, packet.size );
+                    Debug(1, "In packet %d(%x)", packet.size, packet.size );
                     Hexdump( 0, packet.data, packet.size>256?256:packet.size );
                     VideoFrame *videoFrame = new VideoFrame( this, videoFrameCount, packet.pts, packet.data, packet.size );
                     distributeFrame( FramePtr( videoFrame ) );


### PR DESCRIPTION
Current logs are way too verbose. Info really should be minimal and relevant. I think its reasonable to expect the user to get to Debuglevel 1 for others. @web2wire feel free to turn some of them back to Info, but I think we should definitely avoid Info'ing logs that have a tendency to keep printing in a loop (like waitForProviders())
